### PR TITLE
Fix Installation from source command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you want to compile for Python 3, you need to:
 
 Then, to install, just:
 
-    $ make install
+    $ sudo python setup.py install
 
 Usage
 =====


### PR DESCRIPTION
`make install` results in error since no `install` argument is defined in *makefile*

Instead `sudo python setup.py install` works and installs pygattlib successfully.

*Tested on Debian/Stretch.*